### PR TITLE
Update rr_decode.py

### DIFF
--- a/rr_decode.py
+++ b/rr_decode.py
@@ -13,7 +13,7 @@ def decode_b0747746(enc_data):
             x1 = (xor_key & 8) == 8
             x2 = xor_key & 1
             x3 = 1 + (x0 ^ x1 ^ x2)
-            xor_key = (xor_key + xor_key) + x3
+            xor_key = ((xor_key + xor_key) + x3) & 0xFFFFFFFF
         dec_data.append(int.from_bytes(enc_data[i], "little") ^ (xor_key % 256))
 
     return dec_data
@@ -59,7 +59,7 @@ def decode_f2a32072(enc_data):
             x1 = (xor_key & 8) == 8
             x2 = xor_key & 1
             x3 = x0 ^ x1 ^ x2
-            xor_key = (xor_key + xor_key) + x3
+            xor_key = ((xor_key + xor_key) + x3) & 0xFFFFFFFF
         dec_data.append(int.from_bytes(enc_data[i], "little") ^ (xor_key % 256))
 
     return dec_data
@@ -102,7 +102,7 @@ def decode_945fdad8(enc_data):
             x1 = (xor_key & 8) == 8
             x2 = xor_key & 1
             x3 = 1 + (x0 ^ x1 ^ x2)
-            xor_key = (xor_key + xor_key) + x3
+            xor_key = ((xor_key + xor_key) + x3) & 0xFFFFFFFF
         dec_data.append(int.from_bytes(enc_data[i], "little") ^ (xor_key % 256))
 
     return dec_data
@@ -120,7 +120,7 @@ def decode_95a2748e(enc_data):
             x1 = (xor_key & 8) == 8
             x2 = xor_key & 1
             x3 = 1 + (x0 ^ x1 ^ x2)
-            xor_key = (xor_key + xor_key) + x3
+            xor_key = ((xor_key + xor_key) + x3) & 0xFFFFFFFF
         dec_data.append(int.from_bytes(enc_data[i], "little") ^ (xor_key % 256))
 
     return dec_data


### PR DESCRIPTION
Original:
[!] Type [b0747746] is Detected!
[+] Decoding...
[!] Complete!
         1163296 function calls in 194.454 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1  194.239  194.239  194.336  194.336 rr_decode.py:3(decode_b0747746)
        1    0.069    0.069  194.453  194.453 rr_decode.py:128(main)
   581632    0.066    0.000    0.066    0.000 {method 'append' of 'list' objects}
   290820    0.054    0.000    0.054    0.000 {built-in method from_bytes}
   290817    0.023    0.000    0.023    0.000 {method 'read' of '_io.BufferedReader' objects}
        1    0.001    0.001  194.453  194.453 rr_decode.py:1(<module>)
        2    0.000    0.000    0.000    0.000 {built-in method io.open}
        1    0.000    0.000    0.000    0.000 {method 'write' of '_io.BufferedWriter' objects}
        2    0.000    0.000    0.000    0.000 {method '__exit__' of '_io._IOBase' objects}
        3    0.000    0.000    0.000    0.000 {built-in method builtins.print}
        6    0.000    0.000    0.000    0.000 cp1251.py:18(encode)
        6    0.000    0.000    0.000    0.000 {built-in method _codecs.charmap_encode}
        1    0.000    0.000  194.454  194.454 {built-in method builtins.exec}
        2    0.000    0.000    0.000    0.000 {built-in method builtins.len}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}

New:
[!] Type [b0747746] is Detected!
[+] Decoding...
[!] Complete!
         1163296 function calls in 0.862 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.694    0.694    0.743    0.743 rr_decode.py:3(decode_b0747746)
        1    0.070    0.070    0.861    0.861 rr_decode.py:128(main)
   581632    0.048    0.000    0.048    0.000 {method 'append' of 'list' objects}
   290820    0.026    0.000    0.026    0.000 {built-in method from_bytes}
   290817    0.023    0.000    0.023    0.000 {method 'read' of '_io.BufferedReader' objects}
        1    0.001    0.001    0.862    0.862 rr_decode.py:1(<module>)
        2    0.000    0.000    0.000    0.000 {built-in method io.open}
        1    0.000    0.000    0.000    0.000 {method 'write' of '_io.BufferedWriter' objects}
        2    0.000    0.000    0.000    0.000 {method '__exit__' of '_io._IOBase' objects}
        3    0.000    0.000    0.000    0.000 {built-in method builtins.print}
        6    0.000    0.000    0.000    0.000 cp1251.py:18(encode)
        6    0.000    0.000    0.000    0.000 {built-in method _codecs.charmap_encode}
        1    0.000    0.000    0.862    0.862 {built-in method builtins.exec}
        2    0.000    0.000    0.000    0.000 {built-in method builtins.len}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}